### PR TITLE
Fix filters panel hidden attribute behavior

### DIFF
--- a/attraktiva-catalog/src/components/SearchBar.module.css
+++ b/attraktiva-catalog/src/components/SearchBar.module.css
@@ -59,6 +59,10 @@
   box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
 }
 
+.filtersPanel[hidden] {
+  display: none;
+}
+
 .field {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a CSS rule so the filters panel is not displayed when the `hidden` attribute is present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3396a8b38832aa1686d83775fb80d