### PR TITLE
feat: compact search filter toggle

### DIFF
--- a/attraktiva-catalog/src/components/SearchBar.module.css
+++ b/attraktiva-catalog/src/components/SearchBar.module.css
@@ -9,7 +9,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  align-items: flex-end;
+  align-items: center;
 }
 
 .searchField {
@@ -18,33 +18,45 @@
 }
 
 .toggleButton {
-  align-self: stretch;
-  padding: 0.65rem 1.25rem;
-  border-radius: 0.75rem;
-  border: 1px solid #2563eb;
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
-  color: #fff;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 160px;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0.25rem;
+  border-radius: 9999px;
+  border: 1px solid #c7d2fe;
+  background-color: #eef2ff;
+  color: #312e81;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .toggleButton:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.2);
+  background-color: #e0e7ff;
+  border-color: #a5b4fc;
 }
 
 .toggleButton:focus-visible {
-  outline: 3px solid rgba(37, 99, 235, 0.4);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.35);
 }
 
 .toggleButton[aria-expanded='true'] {
-  background: linear-gradient(135deg, #1d4ed8, #1e3a8a);
+  background-color: #e0e7ff;
+  border-color: #818cf8;
+}
+
+.toggleIcon {
+  display: inline-flex;
+  width: 1.25rem;
+  height: 1.25rem;
+  color: inherit;
+}
+
+.toggleIcon svg {
+  width: 100%;
+  height: 100%;
 }
 
 .filtersPanel {
@@ -116,17 +128,17 @@
   outline-offset: 2px;
 }
 
-@media (max-width: 480px) {
-  .searchHeader {
-    flex-direction: column;
-    align-items: stretch;
-  }
+  @media (max-width: 480px) {
+    .searchHeader {
+      flex-direction: column;
+      align-items: stretch;
+    }
 
-  .searchField {
-    min-width: 0;
-  }
+    .searchField {
+      min-width: 0;
+    }
 
-  .toggleButton {
-    width: 100%;
+    .toggleButton {
+      align-self: flex-start;
+    }
   }
-}

--- a/attraktiva-catalog/src/components/SearchBar.tsx
+++ b/attraktiva-catalog/src/components/SearchBar.tsx
@@ -132,9 +132,17 @@ export default function SearchBar({
           className={styles.toggleButton}
           aria-expanded={isFiltersOpen}
           aria-controls={filtersPanelId}
+          aria-label={isFiltersOpen ? 'Ocultar filtros' : 'Mostrar filtros'}
           onClick={() => setIsFiltersOpen((value) => !value)}
         >
-          {isFiltersOpen ? 'Ocultar filtros' : 'Mostrar filtros'}
+          <span aria-hidden="true" className={styles.toggleIcon}>
+            <svg viewBox="0 0 24 24" role="img" focusable="false">
+              <path
+                d="M4.5 6.75h15a.75.75 0 0 0 0-1.5h-15a.75.75 0 0 0 0 1.5Zm3 5h9a.75.75 0 0 0 0-1.5h-9a.75.75 0 0 0 0 1.5Zm3 5h3a.75.75 0 0 0 0-1.5h-3a.75.75 0 0 0 0 1.5Z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- replace the filter toggle button text with an icon-only control that keeps an accessible label
- simplify the toggle button styling for a compact minimal appearance with hover and focus feedback
- adjust mobile alignment so the icon button remains compact on smaller viewports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d339dac740832a9b6d5b796b26698b