### PR TITLE
Align filter toggle with search input

### DIFF
--- a/attraktiva-catalog/src/components/SearchBar.module.css
+++ b/attraktiva-catalog/src/components/SearchBar.module.css
@@ -9,12 +9,20 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  align-items: center;
 }
 
-.searchField {
+.searchContainer {
+  display: flex;
+  flex-direction: column;
   flex: 1 1 240px;
   min-width: 200px;
+  gap: 0.5rem;
+}
+
+.searchControl {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
 }
 
 .toggleButton {
@@ -22,10 +30,12 @@
   align-items: center;
   justify-content: center;
   width: 2.5rem;
-  height: 2.5rem;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
   padding: 0.25rem;
-  border-radius: 9999px;
+  border-radius: 0.5rem 0 0 0.5rem;
   border: 1px solid #c7d2fe;
+  border-right: none;
   background-color: #eef2ff;
   color: #312e81;
   cursor: pointer;
@@ -35,16 +45,19 @@
 .toggleButton:hover {
   background-color: #e0e7ff;
   border-color: #a5b4fc;
+  border-right: none;
 }
 
 .toggleButton:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.35);
+  border-right: none;
 }
 
 .toggleButton[aria-expanded='true'] {
   background-color: #e0e7ff;
   border-color: #818cf8;
+  border-right: none;
 }
 
 .toggleIcon {
@@ -122,6 +135,18 @@
   min-height: 2.5rem;
 }
 
+.searchInput {
+  flex: 1 1 auto;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: none;
+}
+
+.searchInput:focus {
+  position: relative;
+  z-index: 1;
+}
+
 .input:focus,
 .select:focus {
   outline: 3px solid rgba(59, 130, 246, 0.35);
@@ -134,11 +159,11 @@
       align-items: stretch;
     }
 
-    .searchField {
+    .searchContainer {
       min-width: 0;
     }
 
-    .toggleButton {
-      align-self: flex-start;
+    .searchControl {
+      width: 100%;
     }
   }

--- a/attraktiva-catalog/src/components/SearchBar.tsx
+++ b/attraktiva-catalog/src/components/SearchBar.tsx
@@ -112,38 +112,39 @@ export default function SearchBar({
       onSubmit={(event) => event.preventDefault()}
     >
       <div className={styles.searchHeader}>
-        <div className={`${styles.field} ${styles.searchField}`}>
+        <div className={styles.searchContainer}>
           <label className={styles.label} htmlFor="searchTerm">
             Buscar
           </label>
-          <input
-            id="searchTerm"
-            type="search"
-            name="searchTerm"
-            placeholder="Buscar produtos"
-            value={searchTerm}
-            onChange={handleSearchTermChange}
-            className={styles.input}
-          />
+          <div className={styles.searchControl}>
+            <button
+              type="button"
+              className={styles.toggleButton}
+              aria-expanded={isFiltersOpen}
+              aria-controls={filtersPanelId}
+              aria-label={isFiltersOpen ? 'Ocultar filtros' : 'Mostrar filtros'}
+              onClick={() => setIsFiltersOpen((value) => !value)}
+            >
+              <span aria-hidden="true" className={styles.toggleIcon}>
+                <svg viewBox="0 0 24 24" role="img" focusable="false">
+                  <path
+                    d="M4.5 6.75h15a.75.75 0 0 0 0-1.5h-15a.75.75 0 0 0 0 1.5Zm3 5h9a.75.75 0 0 0 0-1.5h-9a.75.75 0 0 0 0 1.5Zm3 5h3a.75.75 0 0 0 0-1.5h-3a.75.75 0 0 0 0 1.5Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </button>
+            <input
+              id="searchTerm"
+              type="search"
+              name="searchTerm"
+              placeholder="Buscar produtos"
+              value={searchTerm}
+              onChange={handleSearchTermChange}
+              className={`${styles.input} ${styles.searchInput}`}
+            />
+          </div>
         </div>
-
-        <button
-          type="button"
-          className={styles.toggleButton}
-          aria-expanded={isFiltersOpen}
-          aria-controls={filtersPanelId}
-          aria-label={isFiltersOpen ? 'Ocultar filtros' : 'Mostrar filtros'}
-          onClick={() => setIsFiltersOpen((value) => !value)}
-        >
-          <span aria-hidden="true" className={styles.toggleIcon}>
-            <svg viewBox="0 0 24 24" role="img" focusable="false">
-              <path
-                d="M4.5 6.75h15a.75.75 0 0 0 0-1.5h-15a.75.75 0 0 0 0 1.5Zm3 5h9a.75.75 0 0 0 0-1.5h-9a.75.75 0 0 0 0 1.5Zm3 5h3a.75.75 0 0 0 0-1.5h-3a.75.75 0 0 0 0 1.5Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
-        </button>
       </div>
 
       <div


### PR DESCRIPTION
## Summary
- embed the filter toggle button alongside the search input so it stays attached to the field
- adjust search bar styling so the button aligns with the input across desktop and mobile layouts

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d33b815914832a85aaf03af5bc5d25