### PR TITLE
Adjust mobile spacing between search bar and product list

### DIFF
--- a/attraktiva-catalog/src/components/SearchBar.module.css
+++ b/attraktiva-catalog/src/components/SearchBar.module.css
@@ -154,6 +154,11 @@
 }
 
   @media (max-width: 480px) {
+    .searchBar {
+      gap: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+
     .searchHeader {
       flex-direction: column;
       align-items: stretch;

--- a/attraktiva-catalog/src/pages/Home.module.css
+++ b/attraktiva-catalog/src/pages/Home.module.css
@@ -27,7 +27,7 @@
 @media (max-width: 768px) {
   .container {
     padding: 2rem 1.25rem 3rem;
-    gap: 1.5rem;
+    gap: 1rem;
   }
 
   .title {


### PR DESCRIPTION
## Summary
- reduce the mobile spacing between the search bar and product list to better match desktop spacing
- tweak search bar spacing on very small screens for a tighter layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d33dd5b9e4832a88f3b6333e182b25