### PR TITLE
Adjust mobile spacing for home search

### DIFF
--- a/attraktiva-catalog/src/components/SearchBar.module.css
+++ b/attraktiva-catalog/src/components/SearchBar.module.css
@@ -155,8 +155,8 @@
 
   @media (max-width: 480px) {
     .searchBar {
-      gap: 0.75rem;
-      margin-bottom: 0.5rem;
+      gap: 0.5rem;
+      margin-bottom: 0;
     }
 
     .searchHeader {

--- a/attraktiva-catalog/src/pages/Home.module.css
+++ b/attraktiva-catalog/src/pages/Home.module.css
@@ -34,3 +34,9 @@
     font-size: clamp(1.5rem, 6vw, 2.125rem);
   }
 }
+
+@media (max-width: 480px) {
+  .container {
+    gap: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- reduce the search bar's phone breakpoint spacing so it sits flush with the catalog on small screens
- add a 480px breakpoint to shrink the home container gap, keeping desktop spacing unchanged
- verified the phone layout at a 375px viewport width

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3fe06b14c832a98fe775b11d2937e