### PR TITLE
Tighten mobile spacing in search bar

### DIFF
--- a/attraktiva-catalog/src/components/SearchBar.module.css
+++ b/attraktiva-catalog/src/components/SearchBar.module.css
@@ -153,22 +153,29 @@
   outline-offset: 2px;
 }
 
-  @media (max-width: 480px) {
-    .searchBar {
-      gap: 0.75rem;
-      margin-bottom: 0.5rem;
-    }
-
-    .searchHeader {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .searchContainer {
-      min-width: 0;
-    }
-
-    .searchControl {
-      width: 100%;
-    }
+@media (max-width: 480px) {
+  .searchBar {
+    gap: 0.375rem;
+    margin-bottom: 0;
   }
+
+  .searchHeader {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .searchContainer {
+    min-width: 0;
+    gap: 0.25rem;
+  }
+
+  .filtersPanel {
+    gap: 0.5rem;
+    padding: 0.75rem;
+  }
+
+  .searchControl {
+    width: 100%;
+  }
+}

--- a/attraktiva-catalog/src/pages/Home.module.css
+++ b/attraktiva-catalog/src/pages/Home.module.css
@@ -34,3 +34,9 @@
     font-size: clamp(1.5rem, 6vw, 2.125rem);
   }
 }
+
+@media (max-width: 480px) {
+  .container {
+    gap: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- compress the search bar stack on phones by shrinking the overall gap and header spacing
- tighten the search container and filter panel gaps/padding so the catalog cards sit closer underneath on mobile

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3fe06b14c832a98fe775b11d2937e