### PR TITLE
Reduce spacing below search bar

### DIFF
--- a/attraktiva-catalog/src/components/SearchBar.module.css
+++ b/attraktiva-catalog/src/components/SearchBar.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0;
 }
 
 .searchHeader {
@@ -16,7 +16,7 @@
   flex-direction: column;
   flex: 1 1 240px;
   min-width: 200px;
-  gap: 0.5rem;
+  gap: 0.25rem;
 }
 
 .searchControl {

--- a/attraktiva-catalog/src/pages/Home.module.css
+++ b/attraktiva-catalog/src/pages/Home.module.css
@@ -4,7 +4,7 @@
   padding: 3rem 1.5rem 4rem;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: clamp(0.75rem, 1.5vw, 1rem);
 }
 
 .title {
@@ -27,7 +27,7 @@
 @media (max-width: 768px) {
   .container {
     padding: 2rem 1.25rem 3rem;
-    gap: 1rem;
+    gap: 0.75rem;
   }
 
   .title {


### PR DESCRIPTION
## Summary
- reduce vertical gap inside the search bar so the label sits closer to the input
- further decrease spacing between the search area and the rest of the home page layout by tightening the container gap across breakpoints

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d401ca8034832a8093dc823bcc2940