### PR TITLE
Atualiza botões de carrinho na página de produto

### DIFF
--- a/attraktiva-catalog/src/pages/ProductDetail.module.css
+++ b/attraktiva-catalog/src/pages/ProductDetail.module.css
@@ -113,35 +113,60 @@
 
 .cartShortcut {
   flex: 0 0 auto;
-  width: 3rem;
-  height: 3rem;
-  border-radius: 0.9rem;
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  background: rgba(15, 23, 42, 0.9);
-  color: #f8fafc;
-  display: flex;
+  position: relative;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.75rem;
+  border: 1px solid #c7d2fe;
+  background: #eef2ff;
+  color: #312e81;
   text-decoration: none;
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.2);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
-    color 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+    background-color 0.2s ease;
 }
 
 .cartShortcut:hover {
-  transform: translateY(-1px) scale(1.02);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.28);
-  background: rgba(15, 23, 42, 0.95);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(99, 102, 241, 0.2);
+  background: #e0e7ff;
+  border-color: #a5b4fc;
 }
 
 .cartShortcut:focus-visible {
-  outline: 3px solid rgba(37, 99, 235, 0.4);
+  outline: 3px solid rgba(99, 102, 241, 0.35);
   outline-offset: 2px;
 }
 
 .cartShortcutIcon {
-  width: 1.35rem;
-  height: 1.35rem;
+  display: inline-flex;
+  width: 1.5rem;
+  height: 1.5rem;
+  color: inherit;
+}
+
+.cartShortcutIcon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.cartShortcutBadge {
+  position: absolute;
+  top: -0.25rem;
+  right: -0.25rem;
+  min-width: 1.5rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 6px 12px rgba(239, 68, 68, 0.3);
 }
 
 .favoriteButton {
@@ -206,10 +231,6 @@
   min-width: 0;
 }
 
-.priceRow .addToCartIcon {
-  flex-shrink: 0;
-}
-
 .headerActions {
   display: flex;
   align-items: center;
@@ -217,50 +238,51 @@
   justify-self: end;
 }
 
-.addToCartIcon {
-  width: 3rem;
-  height: 3rem;
-  border-radius: 0.9rem;
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  background: rgba(15, 23, 42, 0.06);
-  color: #0f172a;
-  display: flex;
+.addToCartButton {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  background: #e2e8f0;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 0.95rem;
   cursor: pointer;
   transition: background-color 0.2s ease, transform 0.2s ease,
-    border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
-  padding: 0;
+    box-shadow 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
-.addToCartIcon:hover:not(:disabled) {
-  background: rgba(15, 23, 42, 0.12);
-  color: #111827;
+.addToCartButton:hover {
+  background: #cfd8e3;
   transform: translateY(-1px);
-  box-shadow: 0 14px 24px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.1);
 }
 
-.addToCartIcon:focus-visible {
-  outline: 3px solid rgba(37, 99, 235, 0.35);
+.addToCartButton:focus-visible {
+  outline: 3px solid rgba(148, 163, 184, 0.65);
   outline-offset: 2px;
 }
 
-.addToCartIcon:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-  transform: none;
-  box-shadow: none;
+.addToCartButton[data-active='true'] {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: rgba(34, 197, 94, 0.45);
+  color: #166534;
+  box-shadow: 0 12px 24px rgba(34, 197, 94, 0.25);
 }
 
-.addToCartIcon[data-active='true'] {
-  background: rgba(37, 99, 235, 0.15);
-  border-color: rgba(37, 99, 235, 0.4);
-  color: #1d4ed8;
+.addToCartButtonIcon {
+  display: inline-flex;
+  width: 1.35rem;
+  height: 1.35rem;
+  color: inherit;
 }
 
-.addToCartIconSvg {
-  width: 1.4rem;
-  height: 1.4rem;
+.addToCartButtonIcon svg {
+  width: 100%;
+  height: 100%;
 }
 
 .cartStatus {

--- a/attraktiva-catalog/src/pages/ProductDetail.tsx
+++ b/attraktiva-catalog/src/pages/ProductDetail.tsx
@@ -47,6 +47,14 @@ export default function ProductDetail() {
     ? 'Remover dos favoritos'
     : 'Adicionar aos favoritos'
   const isInCart = product ? items.some((item) => item.product.id === product.id) : false
+  const cartItemCount = items.reduce((total, item) => total + item.quantity, 0)
+  const cartLabel =
+    cartItemCount === 0
+      ? 'Abrir carrinho'
+      : `Abrir carrinho com ${cartItemCount} produto${
+          cartItemCount > 1 ? 's' : ''
+        }`
+  const addToCartLabel = isInCart ? 'Produto no carrinho' : 'Adicionar ao carrinho'
 
   function handleFavoriteClick() {
     if (product) {
@@ -135,20 +143,22 @@ export default function ProductDetail() {
               <Link
                 to="/cart"
                 className={styles.cartShortcut}
-                aria-label="Ir para o carrinho"
-                title="Ir para o carrinho"
+                aria-label={cartLabel}
+                title="Carrinho de compras"
               >
-                <svg
-                  aria-hidden="true"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                  className={styles.cartShortcutIcon}
-                >
-                  <path
-                    d="M7.5 21a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm9 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm-9.63-6.75a1.25 1.25 0 0 1-1.21-.92L3.28 5.88H2a.75.75 0 0 1 0-1.5h1.83c.56 0 1.05.38 1.21.92l.54 1.85h13.87a1.25 1.25 0 0 1 1.21 1.58l-1.35 4.74a2.25 2.25 0 0 1-2.16 1.67H6.87Z"
-                    fill="currentColor"
-                  />
-                </svg>
+                <span aria-hidden="true" className={styles.cartShortcutIcon}>
+                  <svg viewBox="0 0 24 24" role="img" focusable="false">
+                    <path
+                      d="M7.5 21a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm9 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm-9.63-6.75a1.25 1.25 0 0 1-1.21-.92L3.28 5.88H2a.75.75 0 0 1 0-1.5h1.83c.56 0 1.05.38 1.21.92l.54 1.85h13.87a1.25 1.25 0 0 1 1.21 1.58l-1.35 4.74a2.25 2.25 0 0 1-2.16 1.67H6.87Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+                {cartItemCount > 0 && (
+                  <span className={styles.cartShortcutBadge} aria-hidden="true">
+                    {cartItemCount}
+                  </span>
+                )}
               </Link>
             </div>
           </div>
@@ -156,29 +166,28 @@ export default function ProductDetail() {
           <div className={styles.priceRow}>
             <button
               type="button"
-              className={styles.addToCartIcon}
+              className={styles.addToCartButton}
               data-active={isInCart ? 'true' : 'false'}
               onClick={handleAddToCart}
-              disabled={isInCart}
               aria-pressed={isInCart}
               aria-label={
-                isInCart ? 'Produto já está no carrinho' : 'Adicionar produto ao carrinho'
+                isInCart
+                  ? 'Adicionar mais unidades do produto ao carrinho'
+                  : 'Adicionar produto ao carrinho'
               }
               title={
-                isInCart ? 'Produto já está no carrinho' : 'Adicionar produto ao carrinho'
+                isInCart ? 'Adicionar mais unidades do produto ao carrinho' : 'Adicionar produto ao carrinho'
               }
             >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                viewBox="0 0 24 24"
-                className={styles.addToCartIconSvg}
-              >
-                <path
-                  d="M7.5 21a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm9 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm-9.63-6.75a1.25 1.25 0 0 1-1.21-.92L3.28 5.88H2a.75.75 0 0 1 0-1.5h1.83c.56 0 1.05.38 1.21.92l.54 1.85h13.87a1.25 1.25 0 0 1 1.21 1.58l-1.35 4.74a2.25 2.25 0 0 1-2.16 1.67H6.87Z"
-                  fill="currentColor"
-                />
-              </svg>
+              <span aria-hidden="true" className={styles.addToCartButtonIcon}>
+                <svg viewBox="0 0 24 24" role="img" focusable="false">
+                  <path
+                    d="M7.5 21a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm9 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm-9.63-6.75a1.25 1.25 0 0 1-1.21-.92L3.28 5.88H2a.75.75 0 0 1 0-1.5h1.83c.56 0 1.05.38 1.21.92l.54 1.85h13.87a1.25 1.25 0 0 1 1.21 1.58l-1.35 4.74a2.25 2.25 0 0 1-2.16 1.67H6.87Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+              {addToCartLabel}
             </button>
             <p className={styles.price}>
               {typeof product.price === 'number'
@@ -186,9 +195,6 @@ export default function ProductDetail() {
                 : 'Preço indisponível'}
             </p>
           </div>
-          {isInCart && (
-            <p className={styles.cartStatus}>Produto no carrinho</p>
-          )}
           <dl className={styles.details}>
             <div className={styles.detailItem}>
               <dt className={styles.detailLabel}>Fabricante</dt>


### PR DESCRIPTION
## Summary
- adapta o atalho do carrinho na página de produto para o mesmo estilo do catálogo, com badge de quantidade
- substitui o ícone de adicionar ao carrinho por um botão completo com feedback visual semelhante ao card de produto

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d43fefa478832a96379a21f93748d4