### PR TITLE
Fix cart card layout and truncate overflowing text

### DIFF
--- a/attraktiva-catalog/src/pages/Cart.module.css
+++ b/attraktiva-catalog/src/pages/Cart.module.css
@@ -99,9 +99,10 @@
 
 .gallery {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 1.25rem;
   align-items: stretch;
+  justify-items: center;
 }
 
 .card {
@@ -113,6 +114,8 @@
   box-shadow: 0 12px 28px rgba(15, 23, 42, 0.07);
   overflow: hidden;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  width: 100%;
+  max-width: 260px;
 }
 
 .card:hover {
@@ -154,6 +157,7 @@
   flex-direction: column;
   gap: 0.65rem;
   padding: 1.15rem 1.25rem;
+  flex: 1 1 auto;
 }
 
 .cardHeader {
@@ -168,6 +172,11 @@
   font-size: 1rem;
   color: #0f172a;
   line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .removeButton {
@@ -203,8 +212,9 @@
 
 .metaList li {
   display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
 }
 
 .metaLabel {
@@ -215,6 +225,23 @@
 .metaValue {
   color: #111827;
   font-weight: 600;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+  word-break: break-word;
+}
+
+@media (max-width: 640px) {
+  .gallery {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  }
+
+  .card {
+    max-width: 100%;
+  }
 }
 
 

--- a/attraktiva-catalog/src/pages/Cart.tsx
+++ b/attraktiva-catalog/src/pages/Cart.tsx
@@ -117,6 +117,8 @@ export default function Cart() {
             {items.map((item) => {
               const { product, notes, quantity } = item
               const image = product.image || product.images[0] || ''
+              const manufacturer = product.manufacturer || 'Não informado'
+              const productReference = product.productReference || 'Não informado'
 
               return (
                 <article key={product.id} className={styles.card}>
@@ -131,7 +133,9 @@ export default function Cart() {
                   </div>
                   <div className={styles.cardContent}>
                     <div className={styles.cardHeader}>
-                      <h2 className={styles.productName}>{product.name}</h2>
+                      <h2 className={styles.productName} title={product.name}>
+                        {product.name}
+                      </h2>
                       <button
                         type="button"
                         className={styles.removeButton}
@@ -147,11 +151,15 @@ export default function Cart() {
                       </li>
                       <li>
                         <span className={styles.metaLabel}>Fabricante</span>
-                        <span className={styles.metaValue}>{product.manufacturer || 'Não informado'}</span>
+                        <span className={styles.metaValue} title={manufacturer}>
+                          {manufacturer}
+                        </span>
                       </li>
                       <li>
                         <span className={styles.metaLabel}>Referência</span>
-                        <span className={styles.metaValue}>{product.productReference || 'Não informado'}</span>
+                        <span className={styles.metaValue} title={productReference}>
+                          {productReference}
+                        </span>
                       </li>
                     </ul>
                     <div className={styles.purchaseRow}>


### PR DESCRIPTION
## Summary
- keep cart product cards at a consistent width and center them within the gallery
- allow card content to stretch vertically while clamping long titles and metadata with ellipsis tooltips
- tweak responsive breakpoints so the layout stays legible on small screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d44bab243c832a807d793e213739a6