### PR TITLE
refactor: keep cart quantity and notes visible

### DIFF
--- a/attraktiva-catalog/src/pages/Cart.module.css
+++ b/attraktiva-catalog/src/pages/Cart.module.css
@@ -167,6 +167,33 @@
   gap: 0.5rem;
 }
 
+.toggleInfoButton {
+  border: none;
+  background: transparent;
+  color: #2563eb;
+  font-weight: 600;
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+  padding: 0;
+  margin-top: 0.25rem;
+  align-self: flex-start;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.toggleInfoButton:hover {
+  color: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.toggleInfoButton:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.3);
+  outline-offset: 2px;
+  border-radius: 999px;
+}
+
 .productName {
   margin: 0;
   font-size: 1rem;

--- a/attraktiva-catalog/src/pages/Cart.tsx
+++ b/attraktiva-catalog/src/pages/Cart.tsx
@@ -14,6 +14,7 @@ function formatCurrency(value: number | null | undefined) {
 
 export default function Cart() {
   const { items, removeItem, clearCart, updateNotes, updateQuantity } = useCart()
+  const [expandedItems, setExpandedItems] = useState<Record<number, boolean>>({})
   const [vendorEmail, setVendorEmail] = useState(() => {
     if (typeof window === 'undefined') {
       return ''
@@ -51,6 +52,13 @@ export default function Cart() {
 
   function handleEmailChange(event: ChangeEvent<HTMLInputElement>) {
     setVendorEmail(event.target.value)
+  }
+
+  function handleToggleDetails(productId: number) {
+    setExpandedItems((previous) => ({
+      ...previous,
+      [productId]: !previous[productId],
+    }))
   }
 
   function handleSendQuote(event: FormEvent<HTMLFormElement>) {
@@ -119,6 +127,7 @@ export default function Cart() {
               const image = product.image || product.images[0] || ''
               const manufacturer = product.manufacturer || 'Não informado'
               const productReference = product.productReference || 'Não informado'
+              const isExpanded = expandedItems[product.id] ?? false
 
               return (
                 <article key={product.id} className={styles.card}>
@@ -144,34 +153,46 @@ export default function Cart() {
                         Remover
                       </button>
                     </div>
-                    <ul className={styles.metaList}>
-                      <li>
-                        <span className={styles.metaLabel}>ID</span>
-                        <span className={styles.metaValue}>#{product.id}</span>
-                      </li>
-                      <li>
-                        <span className={styles.metaLabel}>Fabricante</span>
-                        <span className={styles.metaValue} title={manufacturer}>
-                          {manufacturer}
-                        </span>
-                      </li>
-                      <li>
-                        <span className={styles.metaLabel}>Referência</span>
-                        <span className={styles.metaValue} title={productReference}>
-                          {productReference}
-                        </span>
-                      </li>
-                    </ul>
-                    <div className={styles.purchaseRow}>
-                      <div className={styles.priceBlock}>
-                        <span className={styles.priceLabel}>Preço unitário</span>
-                        <span className={styles.priceValue}>{formatCurrency(product.price)}</span>
-                        {typeof product.price === 'number' && (
-                          <span className={styles.lineTotal}>
-                            Total: {formatCurrency(product.price * quantity)}
+                    <button
+                      type="button"
+                      className={styles.toggleInfoButton}
+                      onClick={() => handleToggleDetails(product.id)}
+                      aria-expanded={isExpanded}
+                    >
+                      {isExpanded ? 'Ocultar informações' : 'Ver informações'}
+                    </button>
+                    {isExpanded && (
+                      <ul className={styles.metaList}>
+                        <li>
+                          <span className={styles.metaLabel}>ID</span>
+                          <span className={styles.metaValue}>#{product.id}</span>
+                        </li>
+                        <li>
+                          <span className={styles.metaLabel}>Fabricante</span>
+                          <span className={styles.metaValue} title={manufacturer}>
+                            {manufacturer}
                           </span>
-                        )}
-                      </div>
+                        </li>
+                        <li>
+                          <span className={styles.metaLabel}>Referência</span>
+                          <span className={styles.metaValue} title={productReference}>
+                            {productReference}
+                          </span>
+                        </li>
+                      </ul>
+                    )}
+                    <div className={styles.purchaseRow}>
+                      {isExpanded && (
+                        <div className={styles.priceBlock}>
+                          <span className={styles.priceLabel}>Preço unitário</span>
+                          <span className={styles.priceValue}>{formatCurrency(product.price)}</span>
+                          {typeof product.price === 'number' && (
+                            <span className={styles.lineTotal}>
+                              Total: {formatCurrency(product.price * quantity)}
+                            </span>
+                          )}
+                        </div>
+                      )}
                       <div className={styles.quantityBlock}>
                         <span className={styles.quantityLabel}>Quantidade</span>
                         <QuantitySelector


### PR DESCRIPTION
## Summary
- keep quantity controls and notes fields visible for each cart item while hiding only metadata behind the toggle
- continue to reveal manufacturer, reference, and pricing details when the user expands the product card

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d44da86cc8832aa3c67ca97461d706