### PR TITLE
Align cart remove button with quantity selector

### DIFF
--- a/attraktiva-catalog/src/pages/Cart.module.css
+++ b/attraktiva-catalog/src/pages/Cart.module.css
@@ -167,6 +167,14 @@
   gap: 0.5rem;
 }
 
+.quantitySection {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .toggleInfoButton {
   border: none;
   background: transparent;
@@ -215,6 +223,10 @@
   padding: 0.35rem 0.85rem;
   cursor: pointer;
   transition: background-color 0.2s ease, transform 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.25rem;
 }
 
 .removeButton:hover {

--- a/attraktiva-catalog/src/pages/Cart.tsx
+++ b/attraktiva-catalog/src/pages/Cart.tsx
@@ -145,13 +145,6 @@ export default function Cart() {
                       <h2 className={styles.productName} title={product.name}>
                         {product.name}
                       </h2>
-                      <button
-                        type="button"
-                        className={styles.removeButton}
-                        onClick={() => removeItem(product.id)}
-                      >
-                        Excluir
-                      </button>
                     </div>
                     <button
                       type="button"
@@ -193,14 +186,23 @@ export default function Cart() {
                           )}
                         </div>
                       )}
-                      <div className={styles.quantityBlock}>
-                        <span className={styles.quantityLabel}>Quantidade</span>
-                        <QuantitySelector
-                          value={quantity}
-                          onChange={(nextQuantity) => updateQuantity(product.id, nextQuantity)}
-                          decreaseLabel={`Diminuir quantidade de ${product.name}`}
-                          increaseLabel={`Aumentar quantidade de ${product.name}`}
-                        />
+                      <div className={styles.quantitySection}>
+                        <div className={styles.quantityBlock}>
+                          <span className={styles.quantityLabel}>Quantidade</span>
+                          <QuantitySelector
+                            value={quantity}
+                            onChange={(nextQuantity) => updateQuantity(product.id, nextQuantity)}
+                            decreaseLabel={`Diminuir quantidade de ${product.name}`}
+                            increaseLabel={`Aumentar quantidade de ${product.name}`}
+                          />
+                        </div>
+                        <button
+                          type="button"
+                          className={styles.removeButton}
+                          onClick={() => removeItem(product.id)}
+                        >
+                          Excluir
+                        </button>
                       </div>
                     </div>
                     <label className={styles.notesLabel} htmlFor={`notes-${product.id}`}>


### PR DESCRIPTION
## Summary
- move the remove button inside the cart purchase row so it sits beside the quantity selector
- add layout styles to keep the quantity selector and delete button centered together

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d450b3bfc4832ab4fc789b03f9f3c6