### PR TITLE
Centralize cart remove button with quantity selector

### DIFF
--- a/attraktiva-catalog/src/pages/Cart.module.css
+++ b/attraktiva-catalog/src/pages/Cart.module.css
@@ -169,10 +169,9 @@
 
 .quantitySection {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.4rem;
 }
 
 .toggleInfoButton {
@@ -324,11 +323,12 @@
 }
 
 
-.quantityBlock {
+.quantityControls {
   display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 
@@ -519,7 +519,8 @@
     align-items: flex-start;
   }
 
-  .quantityBlock {
+  .quantityControls {
+    justify-content: space-between;
     width: 100%;
   }
 }

--- a/attraktiva-catalog/src/pages/Cart.tsx
+++ b/attraktiva-catalog/src/pages/Cart.tsx
@@ -187,22 +187,22 @@ export default function Cart() {
                         </div>
                       )}
                       <div className={styles.quantitySection}>
-                        <div className={styles.quantityBlock}>
-                          <span className={styles.quantityLabel}>Quantidade</span>
+                        <span className={styles.quantityLabel}>Quantidade</span>
+                        <div className={styles.quantityControls}>
                           <QuantitySelector
                             value={quantity}
                             onChange={(nextQuantity) => updateQuantity(product.id, nextQuantity)}
                             decreaseLabel={`Diminuir quantidade de ${product.name}`}
                             increaseLabel={`Aumentar quantidade de ${product.name}`}
                           />
+                          <button
+                            type="button"
+                            className={styles.removeButton}
+                            onClick={() => removeItem(product.id)}
+                          >
+                            Excluir
+                          </button>
                         </div>
-                        <button
-                          type="button"
-                          className={styles.removeButton}
-                          onClick={() => removeItem(product.id)}
-                        >
-                          Excluir
-                        </button>
                       </div>
                     </div>
                     <label className={styles.notesLabel} htmlFor={`notes-${product.id}`}>


### PR DESCRIPTION
## Summary
- reorganize the cart quantity controls to wrap the quantity selector and delete button together
- adjust cart styles so the quantity label sits above centered controls and the remove button stays aligned with the selector

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d45195dc88832a9bea26cf3107f298